### PR TITLE
Modified tags feature to work on a per-server basis so that there is …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ token
 log.txt
 
 #ignore tag data
-tags.data
+*tags.data


### PR DESCRIPTION
…no overlap of tags if we run on multiple servers. this was achieved by affixing the guild_id to the start of the file name. any previous installations will have to either re-add all tags manually or change the old tags.data file name to one prefixed with the guilds id