### PR TITLE
Fix jisho bug

### DIFF
--- a/lib/modules/jisho.ex
+++ b/lib/modules/jisho.ex
@@ -39,6 +39,7 @@ defmodule TougouBot.Modules.Jisho do
       {:error, response} ->
         @jisho_error_embed
         |> field("エラーが発生しました", response)
+        |> send
     end
   end
 
@@ -49,7 +50,10 @@ defmodule TougouBot.Modules.Jisho do
         {:ok, Poison.decode!(result)}
       {:ok, %HTTPoison.Response{status_code: 404}} ->
         IO.puts("jisho api 404")
-        {:error, 404}
+        {:error, "HTTP 404"}
+      {:ok, %HTTPoison.Response{status_code: 400}} ->
+        IO.puts("Jisho think we're sending it malformed data, 400 error")
+        {:error, "HTTP 400"}
       {:error, %HTTPoison.Error{reason: e}} ->
         IO.inspect(e)
         {:error, "HTTPoison Error."}

--- a/lib/modules/jisho.ex
+++ b/lib/modules/jisho.ex
@@ -51,8 +51,10 @@ defmodule TougouBot.Modules.Jisho do
       {:ok, %HTTPoison.Response{status_code: 404}} ->
         IO.puts("jisho api 404")
         {:error, "HTTP 404"}
-      {:ok, %HTTPoison.Response{status_code: 400}} ->
+      {:ok, %HTTPoison.Response{status_code: 400, body: result}} ->
         IO.puts("Jisho think we're sending it malformed data, 400 error")
+        IO.inspect("http://jisho.org/api/v1/search/words?keyword="<>term)
+        IO.inspect(result)
         {:error, "HTTP 400"}
       {:error, %HTTPoison.Error{reason: e}} ->
         IO.inspect(e)

--- a/lib/modules/jisho.ex
+++ b/lib/modules/jisho.ex
@@ -45,7 +45,7 @@ defmodule TougouBot.Modules.Jisho do
 
   def search(term) do
     HTTPoison.start()
-    case HTTPoison.get("http://jisho.org/api/v1/search/words?keyword="<>term) do
+    case HTTPoison.get("http://jisho.org/api/v1/search/words?keyword="<>URI.encode_www_form(term)) do
       {:ok, %HTTPoison.Response{status_code: 200, body: result, headers: _}} -> 
         {:ok, Poison.decode!(result)}
       {:ok, %HTTPoison.Response{status_code: 404}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TougouBot.Mixfile do
   def project do
     [
       app: :tougou_bot,
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       deps: deps()


### PR DESCRIPTION
The jisho module stopped accpeting unicode text for a reason I'm not entirely sure of because all the other modules still accept japanese text etc. this was fixed by using URI.encode_www_form.  
Error logging was also improved.