### PR TITLE
Fix a bug in the jisho command where words with the same reading as kanji error out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "tougou_bot"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tougou_bot"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Alexander Hammatt <alexander.hammatt@protonmail.com>"]
 edition = "2018"
 

--- a/src/data_access/jisho_repository/jisho_org_repository.rs
+++ b/src/data_access/jisho_repository/jisho_org_repository.rs
@@ -68,11 +68,11 @@ impl JishoRepository for JishoOrgRepository {
         })?;
 
         Ok(JishoDefinition {
-            word: japanese_section
-                .word
-                .clone()
-                .ok_or_else(|| JishoOrgRepositoryError::new(String::from("word was empty")))?
-                .clone(),
+            word: match japanese_section
+                .word.clone() {
+                    Some(word) => word,
+                    None => japanese_section.reading.clone(),
+                },
             reading: japanese_section.reading.clone(),
             english_definitions: senses_section.english_definitions.clone(),
             parts_of_speech: senses_section.parts_of_speech.clone(),


### PR DESCRIPTION
related to how the jisho.org api works. we need to check to see if the "word" field exists and fill it with the value from reading if not.